### PR TITLE
feat(go)!: Bump Go to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sonjek/go-lastfm
 
-go 1.19
+go 1.20


### PR DESCRIPTION
Support for the three latest versions should be enough.